### PR TITLE
Coach and Coach Roster CRUD and APIs

### DIFF
--- a/src/main/java/com/gym/roster/controller/CoachController.java
+++ b/src/main/java/com/gym/roster/controller/CoachController.java
@@ -1,7 +1,7 @@
 package com.gym.roster.controller;
 
-import com.gym.roster.domain.Athlete;
-import com.gym.roster.service.AthleteService;
+import com.gym.roster.domain.Coach;
+import com.gym.roster.service.CoachService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,56 +21,52 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/athlete")
-public class AthleteController {
+@RequestMapping("/coach")
+public class CoachController {
 
-    private final AthleteService athleteService;
+    private final CoachService coachService;
 
     @Autowired
-    public AthleteController(AthleteService athleteService) {
-        this.athleteService = athleteService;
+    public CoachController(CoachService coachService) {
+        this.coachService = coachService;
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Athlete> findById(@PathVariable UUID id) {
-        return athleteService.findById(id)
+    public ResponseEntity<Coach> findById(@PathVariable UUID id) {
+        return coachService.findById(id)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @PostMapping
-    public ResponseEntity<Athlete> create(@RequestBody Athlete athlete) {
-        Athlete createdAthlete = athleteService.save(athlete);
-        return new ResponseEntity<>(createdAthlete, HttpStatus.CREATED);
+    public ResponseEntity<Coach> create(@RequestBody Coach coach) {
+        Coach createdCoach = coachService.save(coach);
+        return new ResponseEntity<>(createdCoach, HttpStatus.CREATED);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Athlete> update(@PathVariable UUID id, @RequestBody Athlete athlete) {
-        return athleteService.findById(id)
-                .map(existingAthlete -> {
-                    existingAthlete.setClubName(athlete.getClubName());
-                    existingAthlete.setFirstName(athlete.getFirstName());
-                    existingAthlete.setLastName(athlete.getLastName());
-                    existingAthlete.setHomeCountry(athlete.getHomeCountry());
-                    existingAthlete.setHomeState(athlete.getHomeState());
-                    existingAthlete.setHomeCity(athlete.getHomeCity());
-                    return ResponseEntity.ok(athleteService.save(existingAthlete));
+    public ResponseEntity<Coach> update(@PathVariable UUID id, @RequestBody Coach coach) {
+        return coachService.findById(id)
+                .map(existingCoach -> {
+                    existingCoach.setFirstName(coach.getFirstName());
+                    existingCoach.setLastName(coach.getLastName());
+                    return ResponseEntity.ok(coachService.save(existingCoach));
                 })
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteById(@PathVariable UUID id) {
-        athleteService.deleteById(id);
+        coachService.deleteById(id);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping
-    public ResponseEntity<Page<Athlete>> getPaginatedEntities(
+    public ResponseEntity<Page<Coach>> getPaginatedEntities(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<Athlete> athletes = athleteService.getPaginatedEntities(pageable);
-        return ResponseEntity.ok(athletes);
+        Page<Coach> coaches = coachService.getPaginatedEntities(pageable);
+        return ResponseEntity.ok(coaches);
     }
 }

--- a/src/main/java/com/gym/roster/controller/CoachRosterController.java
+++ b/src/main/java/com/gym/roster/controller/CoachRosterController.java
@@ -1,0 +1,71 @@
+package com.gym.roster.controller;
+
+import com.gym.roster.domain.Coach;
+import com.gym.roster.domain.CoachRoster;
+import com.gym.roster.parser.CoachRosterImportResult;
+import com.gym.roster.service.CoachRosterService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/roster/coach")
+public class CoachRosterController {
+
+    private final CoachRosterService coachRosterService;
+
+    @Autowired
+    public CoachRosterController(CoachRosterService coachRosterService) {
+        this.coachRosterService = coachRosterService;
+    }
+
+    @PostMapping
+    public ResponseEntity<CoachRoster> create(@RequestBody CoachRoster coachRoster) {
+        CoachRoster createdCoachRoster = coachRosterService.save(coachRoster);
+        return ResponseEntity.ok(createdCoachRoster);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CoachRoster> findById(@PathVariable UUID id) {
+        return coachRosterService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{seasonYear}/{collegeCodeName}")
+    public ResponseEntity<List<CoachRoster>> getCollegeCoachRosterForSeason(
+            @PathVariable Short seasonYear,
+            @PathVariable String collegeCodeName) {
+        return ResponseEntity.ok(coachRosterService.findByYearAndCollegeCode(seasonYear, collegeCodeName));
+    }
+
+    @DeleteMapping("/{seasonYear}/{collegeCodeName}")
+    public ResponseEntity<Void> deleteCollegeCoachRosterForSeason(
+            @PathVariable Short seasonYear,
+            @PathVariable String collegeCodeName) {
+        //TODO
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/file-import")
+    public ResponseEntity<List<CoachRosterImportResult>> importRosterFromFile(@RequestParam MultipartFile file) {
+        try {
+            List<CoachRosterImportResult> results = new ArrayList<>();
+            return ResponseEntity.ok(results);
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/src/main/java/com/gym/roster/controller/RosterController.java
+++ b/src/main/java/com/gym/roster/controller/RosterController.java
@@ -16,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @RestController
-@RequestMapping("/roster")
+@RequestMapping("/roster/athlete")
 public class RosterController {
 
     private final RosterService rosterService;
@@ -30,7 +30,7 @@ public class RosterController {
         this.athleteService = athleteService;
     }
 
-    @PostMapping("/athlete/file-import")
+    @PostMapping("/file-import")
     public ResponseEntity<List<AthleteRosterImportResult>> importRosterFromFile(@RequestParam MultipartFile file) {
         try {
             AthleteRosterCsvImporter importer = new AthleteRosterCsvImporter(collegeService, athleteService, rosterService);

--- a/src/main/java/com/gym/roster/domain/Coach.java
+++ b/src/main/java/com/gym/roster/domain/Coach.java
@@ -1,0 +1,42 @@
+package com.gym.roster.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "coach", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_coach",
+                columnNames = {"first_name", "last_name"})
+})
+public class Coach {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @NotBlank(message = "First name is required")
+    @Column(name = "first_name", nullable = false)
+    private String firstName;
+
+    @NotBlank(message = "Last name is required")
+    @Column(name = "last_name", nullable = false)
+    private String lastName;
+
+    @Column(name = "creation_timestamp", nullable = false, updatable = false)
+    private Instant creationTimestamp;
+
+    @Column(name = "last_update_timestamp", nullable = false)
+    private Instant lastUpdateTimestamp;
+}

--- a/src/main/java/com/gym/roster/domain/CoachRoster.java
+++ b/src/main/java/com/gym/roster/domain/CoachRoster.java
@@ -1,0 +1,48 @@
+package com.gym.roster.domain;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "coach_roster", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_coach_roster",
+                columnNames = {"season_year", "college_id", "coach_id"})
+})
+public class CoachRoster {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @NotNull(message = "College is required")
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "college_id", nullable = false)
+    private College college;
+
+    @NotNull(message = "Season year is required")
+    @Column(name = "season_year", nullable = false)
+    private Short seasonYear;
+
+    @NotNull(message = "Coach is required")
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "coach_id", nullable = false)
+    private Coach coach;
+
+    @NotBlank(message = "Role code is required")
+    @Column(name = "role_code", nullable = false)
+    private String roleCode;
+
+    @Column(name = "creation_timestamp", nullable = false, updatable = false)
+    private Instant creationTimestamp;
+
+    @Column(name = "last_update_timestamp", nullable = false)
+    private Instant lastUpdateTimestamp;
+
+}

--- a/src/main/java/com/gym/roster/parser/AthleteRosterCsvImporter.java
+++ b/src/main/java/com/gym/roster/parser/AthleteRosterCsvImporter.java
@@ -7,13 +7,10 @@ import com.gym.roster.service.AthleteService;
 import com.gym.roster.service.CollegeService;
 import com.gym.roster.service.RosterService;
 import lombok.Getter;
-import lombok.Setter;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -50,7 +47,6 @@ public class AthleteRosterCsvImporter {
         FIRST_NAME, LAST_NAME, COLLEGE_CLASS,
         HOME_TOWN, HOME_STATE, HOME_COUNTRY,
         CLUB, POSITION
-
     }
 
     public void parseFile(MultipartFile multipartFile) throws IOException{

--- a/src/main/java/com/gym/roster/parser/CoachRosterImportResult.java
+++ b/src/main/java/com/gym/roster/parser/CoachRosterImportResult.java
@@ -1,0 +1,21 @@
+package com.gym.roster.parser;
+
+import com.gym.roster.domain.CoachRoster;
+import lombok.Data;
+
+@Data
+public class CoachRosterImportResult {
+
+    public enum Status {
+        CREATED,
+        UPDATED,
+        EXISTS,
+        ERROR;
+    }
+
+    private Long recordNumber;
+    private Status coachImportStatus;
+    private Status rosterImportStatus;
+    private CoachRoster roster;
+    private String message;
+}

--- a/src/main/java/com/gym/roster/repository/CoachRepository.java
+++ b/src/main/java/com/gym/roster/repository/CoachRepository.java
@@ -1,0 +1,17 @@
+package com.gym.roster.repository;
+
+import com.gym.roster.domain.Coach;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface CoachRepository extends JpaRepository<Coach, UUID> {
+
+    @Query("SELECT c FROM Coach c " +
+            "WHERE UPPER(c.firstName) = UPPER(?1) " +
+            "AND UPPER(c.lastName) = UPPER(?2) ")
+    Coach findByName(String firstName, String lastName);
+}

--- a/src/main/java/com/gym/roster/repository/CoachRosterRepository.java
+++ b/src/main/java/com/gym/roster/repository/CoachRosterRepository.java
@@ -1,0 +1,19 @@
+package com.gym.roster.repository;
+
+import com.gym.roster.domain.Coach;
+import com.gym.roster.domain.CoachRoster;
+import com.gym.roster.domain.College;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface CoachRosterRepository extends JpaRepository<CoachRoster, UUID> {
+
+    @Query("SELECT r FROM CoachRoster r WHERE r.seasonYear = ?1 AND r.college = ?2 AND r.coach = ?3")
+    CoachRoster findByYearAndCollegeAndCoach(Short seasonYear, College college, Coach coach);
+
+    @Query("SELECT r FROM CoachRoster r WHERE r.seasonYear = ?1 AND UPPER(r.college.codeName) = UPPER(?2)")
+    List<CoachRoster> findByYearAndCollegeCodeName(Short seasonYear, String collegeCodeName);
+}

--- a/src/main/java/com/gym/roster/service/CoachRosterService.java
+++ b/src/main/java/com/gym/roster/service/CoachRosterService.java
@@ -1,0 +1,55 @@
+package com.gym.roster.service;
+
+import com.gym.roster.domain.Coach;
+import com.gym.roster.domain.CoachRoster;
+import com.gym.roster.domain.College;
+import com.gym.roster.repository.CoachRosterRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class CoachRosterService {
+
+    private final CoachRosterRepository coachRosterRepository;
+
+    @Autowired
+    public CoachRosterService(CoachRosterRepository coachRosterRepository) {
+        this.coachRosterRepository = coachRosterRepository;
+    }
+
+    public Optional<CoachRoster> findById(UUID id) {
+        return coachRosterRepository.findById(id);
+    }
+
+    public CoachRoster findByYearAndCollegeAndAthlete(Short seasonYear, College college, Coach coach) {
+        return coachRosterRepository.findByYearAndCollegeAndCoach(seasonYear, college, coach);
+    }
+
+    public List<CoachRoster> findByYearAndCollegeCode(Short seasonYear, String collegeCode) {
+        return coachRosterRepository.findByYearAndCollegeCodeName(seasonYear, collegeCode);
+    }
+
+    public CoachRoster save(CoachRoster roster) {
+        Instant now = Instant.now();
+        if (roster.getId() == null) {
+            roster.setCreationTimestamp(now);
+        }
+        roster.setLastUpdateTimestamp(now);
+        return coachRosterRepository.save(roster);
+    }
+
+    public void deleteById(UUID id) {
+        coachRosterRepository.deleteById(id);
+    }
+
+    public Page<CoachRoster> getPaginatedEntities(Pageable pageable) {
+        return coachRosterRepository.findAll(pageable);
+    }
+}

--- a/src/main/java/com/gym/roster/service/CoachService.java
+++ b/src/main/java/com/gym/roster/service/CoachService.java
@@ -1,0 +1,48 @@
+package com.gym.roster.service;
+
+import com.gym.roster.domain.Coach;
+import com.gym.roster.repository.CoachRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class CoachService {
+
+    private final CoachRepository coachRepository;
+
+    @Autowired
+    public CoachService(CoachRepository coachRepository) {
+        this.coachRepository = coachRepository;
+    }
+
+    public Optional<Coach> findById(UUID id) {
+        return coachRepository.findById(id);
+    }
+
+    public Coach findByName(String firstName, String lastName) {
+        return coachRepository.findByName(firstName, lastName);
+    }
+
+    public Coach save(Coach coach) {
+        Instant now = Instant.now();
+        if (coach.getId() == null) {
+            coach.setCreationTimestamp(now);
+        }
+        coach.setLastUpdateTimestamp(now);
+        return coachRepository.save(coach);
+    }
+
+    public void deleteById(UUID id) {
+        coachRepository.deleteById(id);
+    }
+
+    public Page<Coach> getPaginatedEntities(Pageable pageable) {
+        return coachRepository.findAll(pageable);
+    }
+}


### PR DESCRIPTION
## Summary
Initial database CRUD, service and API capability for Coach and CoachRoster.

## Related issues
<!-- Which issue(s) does this PR close, resolve or fix. Use Closes #123. Use "Resolves, Closes, or Fixes" to auto-close the issue. -->
Resolves #20 

## Overview of changes
<!-- Provide a summary of key changes -->

#### Describe changes related to the issue(s):
- Added jpa/repository CRUD and controller APIs for managing coaches.
- Added jpa/repository CRUD and controller APIs for managing coaching rosters for a college's season.

#### Describe any opportune refactorings, if any:
- Updated athlete roster's api path to `roster/athlete`.